### PR TITLE
Pass bot_user_id to event handler, not bot_id

### DIFF
--- a/tiger_agent/harness.py
+++ b/tiger_agent/harness.py
@@ -212,14 +212,19 @@ class AgentHarness:
     @logfire.instrument("fetch_bot_info", extract_args=False)
     async def _fetch_bot_info(self):
         resp = await self.app.client.auth_test()
+        
+        assert isinstance(resp.data, dict), "resp.data must be a dict"
         assert resp.data.get("ok") == True, "slack auth_test failed"
         
-        bot = resp.data.get("bot")
-        assert isinstance(bot, dict), "resp.data.bot must be a dict"
+        bot_id = resp.data.get("bot_id")
         
-        self._bot_user_id: str = bot.get("user_id")
-        self._bot_name: str = bot.get("name")
-        self._app_id: str = bot.get("app_id")
+        bot_info = await self.app.client.bots_info(bot=bot_id)
+        
+        assert isinstance(bot_info.bot, dict), "resp.data must be a dict"
+        
+        self._bot_user_id: str = bot_info.get("user_id")
+        self._bot_name: str = bot_info.get("name")
+        self._app_id: str = bot_info.get("app_id")
 
     def _worker_args(self, num_workers: int) -> list[tuple[int, int]]:
         initial_sleeps: list[int] = [0]  # first worker starts immediately

--- a/tiger_agent/harness.py
+++ b/tiger_agent/harness.py
@@ -55,7 +55,6 @@ class EventContext:
     app: AsyncApp
     pool: AsyncConnectionPool
     task_group: TaskGroup
-    bot_id: str
     bot_user_id: str
     bot_name: str
     app_id: str
@@ -151,7 +150,6 @@ class AgentHarness:
             self.app,
             self.pool,
             self._task_group,
-            self._bot_id,
             self._bot_user_id,
             self._bot_name,
             self._app_id,
@@ -220,7 +218,6 @@ class AgentHarness:
         assert isinstance(bot, dict), "resp.data.bot must be a dict"
         
         self._bot_user_id: str = bot.get("user_id")
-        self._bot_id: str = bot.get("id")
         self._bot_name: str = bot.get("name")
         self._app_id: str = bot.get("app_id")
 

--- a/tiger_agent/harness.py
+++ b/tiger_agent/harness.py
@@ -146,7 +146,7 @@ class AgentHarness:
         ):
             await cur.execute("select agent.delete_expired_events()")
 
-    def th_make_event_context(self) -> EventContext:
+    def _make_event_context(self) -> EventContext:
         return EventContext(
             self.app,
             self.pool,

--- a/tiger_agent/harness.py
+++ b/tiger_agent/harness.py
@@ -56,9 +56,8 @@ class EventContext:
     pool: AsyncConnectionPool
     task_group: TaskGroup
     bot_id: str
+    bot_user_id: str
     bot_name: str
-    team_id: str
-    team_name: str
     app_id: str
 
 
@@ -147,15 +146,14 @@ class AgentHarness:
         ):
             await cur.execute("select agent.delete_expired_events()")
 
-    def _make_event_context(self) -> EventContext:
+    def th_make_event_context(self) -> EventContext:
         return EventContext(
             self.app,
             self.pool,
             self._task_group,
             self._bot_id,
+            self._bot_user_id,
             self._bot_name,
-            self._team_id,
-            self._team_name,
             self._app_id,
         )
 
@@ -216,17 +214,15 @@ class AgentHarness:
     @logfire.instrument("fetch_bot_info", extract_args=False)
     async def _fetch_bot_info(self):
         resp = await self.app.client.auth_test()
-        assert isinstance(resp.data, dict), "resp.data must be a dict"
-        assert resp.data["ok"] == True, "slack auth_test failed"
-        self._bot_id: str = resp.data["bot_id"]
-        self._team_id: str = resp.data["team_id"]
-        self._team_name: str = resp.data["team"]
-        resp = await self.app.client.bots_info(bot=self._bot_id, team_id=self._team_id)
-        assert isinstance(resp.data, dict), "resp.data must be a dict"
-        assert resp.data["ok"] == True, "slack bot_info failed"
-        bot = resp.data["bot"]
-        self._bot_name: str = bot["name"]
-        self._app_id: str = bot["app_id"]
+        assert resp.data.get("ok") == True, "slack auth_test failed"
+        
+        bot = resp.data.get("bot")
+        assert isinstance(bot, dict), "resp.data.bot must be a dict"
+        
+        self._bot_user_id: str = bot.get("user_id")
+        self._bot_id: str = bot.get("id")
+        self._bot_name: str = bot.get("name")
+        self._app_id: str = bot.get("app_id")
 
     def _worker_args(self, num_workers: int) -> list[tuple[int, int]]:
         initial_sleeps: list[int] = [0]  # first worker starts immediately

--- a/tiger_agent/harness.py
+++ b/tiger_agent/harness.py
@@ -220,11 +220,13 @@ class AgentHarness:
         
         bot_info = await self.app.client.bots_info(bot=bot_id)
         
-        assert isinstance(bot_info.bot, dict), "resp.data must be a dict"
+        bot = bot_info.get("bot")
         
-        self._bot_user_id: str = bot_info.get("user_id")
-        self._bot_name: str = bot_info.get("name")
-        self._app_id: str = bot_info.get("app_id")
+        assert isinstance(bot, dict), "bot must be a dict"
+        
+        self._bot_user_id: str = bot.get("user_id")
+        self._bot_name: str = bot.get("name")
+        self._app_id: str = bot.get("app_id")
 
     def _worker_args(self, num_workers: int) -> list[tuple[int, int]]:
         initial_sleeps: list[int] = [0]  # first worker starts immediately


### PR DESCRIPTION
The bot_id is not needed downstream, it is only needed to fetch the bot info. Let's only pass the bot_user_id to the event handler